### PR TITLE
Preserve order of arguments in unification

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -47,6 +47,7 @@ idrisTests
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006",
        "record001", "record002",
+       "reg001",
        "total001", "total002", "total003", "total004", "total005",
        "total006",
        "with001"]

--- a/tests/idris2/reg001/D.idr
+++ b/tests/idris2/reg001/D.idr
@@ -1,0 +1,17 @@
+module D
+
+-- %logging 10
+func1 : Applicative f => (a -> f c) -> (b -> f d) -> (a, b) -> f (c, d)
+func1 fn g (ma, mb) = MkPair <$> fn ma <*> ?gmb
+-- %logging 0
+
+-- %logging 10
+mfunc : (a -> Maybe c) -> (b -> Maybe d) -> (a, b) -> Maybe (c, d)
+mfunc fn g (ma, mb) 
+   = let pairapp = MkPair <$> fn ma in
+         pairapp <*> g mb
+%logging 0
+
+func2 : (a -> c) -> (b -> d) -> a -> b -> (c, d)
+func2 f g a b = MkPair (f a) (g b)
+

--- a/tests/idris2/reg001/expected
+++ b/tests/idris2/reg001/expected
@@ -1,0 +1,1 @@
+1/1: Building D (D.idr)

--- a/tests/idris2/reg001/run
+++ b/tests/idris2/reg001/run
@@ -1,0 +1,3 @@
+$1 --check D.idr
+
+rm -rf build


### PR DESCRIPTION
Sometimes we swap the arguments, to reduce code duplication, but we need
to remember we've done that since (1 x : a) -> b is valid for an
argument of type (x : a) -> b, but not vice versa (that is, we have a
teensy bit of subtying to deal with, for convenience...).

This fix seems a bit ugly, but we do at least now propagate the
information. Fixes #82.